### PR TITLE
fix: Multi-dimensional indexing error

### DIFF
--- a/starfysh/utils.py
+++ b/starfysh/utils.py
@@ -215,7 +215,7 @@ class VisiumArguments:
         n_anchor = self.params['n_anchors']
 
         top_expr_spots = (-score_df.values).argsort(axis=0)[:n_anchor, :]
-        pure_spots = np.transpose(score_df.index[top_expr_spots])
+        pure_spots = np.transpose(np.array(score_df.index)[top_expr_spots])
 
         pure_dict = {
             ct: spot


### PR DESCRIPTION
Fixes the following ValueError thrown in recent pandas versions: ValueError: Multi-dimensional indexing (e.g. obj[:, None]) is no longer supported. Convert to a numpy array before indexing instead.